### PR TITLE
Benchmarks on Jean-Zay with the torch module 2.1.1 and deepspeed 0.12.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ srun pie train -c config.json --training_dist 'fsdp' \
 ```
 
 ## Benchmarks on Jean-Zay
+Libraries version:
+ - Torch : 2.1.1
+ - Deepspeed : 0.12.4
+
 Hyperparameters :
  - Max Sequence Length = 1024
  - No layer freezed
@@ -46,21 +50,21 @@ Hyperparameters :
 #### Llama 7b :
 |n*GPU|Optimized DDP|ZeRO stage|Batch size/gpu|Epoch duration (s)|Training tokens/s|Inference tokens/s|GPU memory allocated(GB)|Avg loss|perplexity|
 |:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
-|4|deepspeed|2|1|795.85|5679|20768|50.91|0.53|1.67|
-|8|deepspeed|2|2|250.64|18739|49488|50.44|0.55|1.64|
-|16|deepspeed|3|4|583.83*|15446*|12441|65.59|0.65|1.65|
-|4|fsdp|/|3|400.43*|15027*|23347|52.12|0.63|1.69|
-|8|fsdp|/|3|203.00|30078|42023|47.41|0.68|1.72|
-|16|fsdp|/|4|602.96|13876|13166|59.10|0.78|1.80|
+|4|deepspeed|3|2|542.12|9176|12124|56.34|0.53|1.65|
+|8|deepspeed|2|3|224.43|21520|53578|64.18|0.57|1.63|
+|16|deepspeed|3|4|574.72*|14134*|11029|65.59|0.65|1.65|
+|4|fsdp|/|3|394.62*|13648*|23495|52.12|0.63|1.69|
+|8|fsdp|/|3|198.73|27371|42343|47.41|0.68|1.72|
+|16|fsdp|/|4|450.57|16420|16530|59.10|0.78|1.80|
 ---
 #### Llama 13b :
 |n*GPU|Optimized DDP|ZeRO stage|Batch size/gpu|Epoch duration (s)|Training tokens/s|Inference tokens/s|GPU memory allocated(GB)|Avg loss|perplexity|
 |:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
-|8|deepspeed|3|1|818.79|5999|7226|48.51|0.52|1.64|
-|16|deepspeed|3|2|1517.03|4430|2958|58.93|0.57|1.62|
-|4|fsdp|/|1|984.05|6223|5984|41.14|0.56|1.63|
-|8|fsdp|/|2|382.03|15294|19318|53.70|0.62|1.66|
-|16|fsdp|/|2|1323.93|5397**|3556**|49.15|0.67|1.70|
+|8|deepspeed|3|1|621.14|8151|7723|48.51|0.52|1.64|
+|16|deepspeed|3|2|1266.39|5065**|3303**|58.93|0.57|1.62|
+|4|fsdp|/|2|754.29|6770|10989|62.82|0.58|1.64|
+|8|fsdp|/|2|399.42|13531|19310|53.71|0.62|1.66|
+|16|fsdp|/|2|1985.68|3707|2378|49.15|0.67|1.70|
 ---
-\* Two configs can have similar training throughput but different epoch duration because the throughput only takes in account, in an iteration, the delta time between the loading of data and the optimizer step whereas the epoch duration which also takes in account an inference part containing the evaluation loop and a test of generating texts.
+\* Two configs can have the same training throughput but different epoch duration because the throughput only takes in account, in an iteration, the delta time between the loading of data and the optimizer step whereas the epoch duration which also takes in account an inference part containing the evaluation loop and a test of generating texts.
 </br>** The training throughput can be faster than the evaluation throughput because the training only deals with batch size with a length of 1024 whereas the evaluation throughput which deals with, in average, shorter sequence length (e.g. : ~256) so the batch size is less optimized.

--- a/README.md
+++ b/README.md
@@ -66,5 +66,5 @@ Hyperparameters :
 |8|fsdp|/|2|399.42|13531|19310|53.71|0.62|1.66|
 |16|fsdp|/|2|1985.68|3707|2378|49.15|0.67|1.70|
 ---
-\* Two configs can have the same training throughput but different epoch duration because the throughput only takes in account, in an iteration, the delta time between the loading of data and the optimizer step whereas the epoch duration which also takes in account an inference part containing the evaluation loop and a test of generating texts.
+\* Two configurations can have the same training throughput but different epoch durations because the throughput only takes into account, in an iteration, the delta time between the loading of data and the optimizer step, whereas the epoch duration also takes into account an inference part containing the evaluation loop and a test of generating texts.
 </br>** The training throughput can be faster than the evaluation throughput because the training only deals with batch size with a length of 1024 whereas the evaluation throughput which deals with, in average, shorter sequence length (e.g. : ~256) so the batch size is less optimized.


### PR DESCRIPTION
The benchmarks are updated using the latest PyTorch module 2.1.1
This replaces the previous benchmarks made using the PyTorch module 2.0.1
What can be relevant is that Deepspeed got a big update (0.10.0 > 0.12.4) with significant improvements, especially ZeRO-3 which became more interesting than ZeRO stage 2 in some cases.
On the other hand, FSDP had some issues obtaining the results of the previous version (2.0.1 > 2.1.1). I noted this point during my personal benchmarks testing Deepspeed and FSDP, the forward is a bit slower. It's maybe due to the big change, which adds the possibility to freeze layers.